### PR TITLE
fixed call to ErrorException namespace

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -39,7 +39,7 @@ class Curl {
 	public function __construct() {
 
 		if (!extension_loaded('curl')) {
-			throw new ErrorException('cURL library is not loaded');
+			throw new \ErrorException('cURL library is not loaded');
 		}
 
 		$this->curl = curl_init();


### PR DESCRIPTION
I was unable to use the class without this small change. After the fix, all the requests works ok.
