### PR TITLE
Update Curl.php

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -50,7 +50,10 @@ class Curl {
 	}
 
 	public function get($url, $data = array()) {
-		$this->setopt(CURLOPT_URL, $url . '?' . http_build_query($data));
+		if (count($data) > 0)
+		    $this->setopt(CURLOPT_URL, $url . '?' . http_build_query($data));
+	        else
+	            $this->setopt(CURLOPT_URL, $url);
 		$this->setopt(CURLOPT_HTTPGET, TRUE);
 		$this->_exec();
 	}


### PR DESCRIPTION
Sometimes, e.g. when you want to perform a get request using same name parameters in the query, it is preferred to build the url with the query parameters in the $url argument and not specify a $data argument. In that case, you do not want a '?' put behind your url, as it messes up the query.
