### PR TITLE
Don’t close the cURL handle more than once

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -121,7 +121,9 @@ class Curl {
 	}
 
 	public function close() {
-		curl_close($this->curl);
+		if (is_resource($this->curl)) {
+			curl_close($this->curl);
+		}
 	}
 
 	public function _exec() {


### PR DESCRIPTION
When close() was called more than once PHP warnings appeared stating that "XY is not a valid cURL handle resource". This was especially problematic when close() was called manually because it will also _always_ be called from the destructor. From no on we’ll first check whether $this->curl is still a resource to avoid that.

Besides that: great Job!
