### PR TITLE
test suite: Add forward compatibility with PHP 7

### DIFF
--- a/tests/server/php-curl-test/server.php
+++ b/tests/server/php-curl-test/server.php
@@ -23,7 +23,7 @@ $data_mapping = array(
 );
 
 if(isset($data_mapping[$test])) {
-    $data = $$data_mapping[$test];
+    $data = ${$data_mapping[$test]};
     $value = isset($data[$key]) ? $data[$key] : '';
 echo $value;
 } else {


### PR DESCRIPTION
Starting in PHP 7, variables will be evaluated from left to right.  Adding {}'s ensure backwards compatibility to PHP 5.x.

[php manual reference](http://php.net/manual/en/migration70.incompatible.php#migration70.incompatible.variable-handling.indirect
)