### PR TITLE
Do not add the query symbol (?) to urls when the query is empty

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -296,10 +296,12 @@ class Curl
      */
     public function put($url, $data = array(), $payload = false)
     {
-        if ($payload === false) {
-            $url .= '?'.http_build_query($data);
-        } else {
-            $this->preparePayload($data);
+        if (! empty($data)) {
+            if ($payload === false) {
+                $url .= '?'.http_build_query($data);
+            } else {
+                $this->preparePayload($data);
+            }
         }
 
         $this->setOpt(CURLOPT_URL, $url);
@@ -320,10 +322,12 @@ class Curl
      */
     public function patch($url, $data = array(), $payload = false)
     {
-        if ($payload === false) {
-            $url .= '?'.http_build_query($data);
-        } else {
-            $this->preparePayload($data);
+        if (! empty($data)) {
+            if ($payload === false) {
+                $url .= '?'.http_build_query($data);
+            } else {
+                $this->preparePayload($data);
+            }
         }
 
         $this->setOpt(CURLOPT_URL, $url);
@@ -342,11 +346,14 @@ class Curl
      */
     public function delete($url, $data = array(), $payload = false)
     {
-        if ($payload === false) {
-            $url .= '?'.http_build_query($data);
-        } else {
-            $this->preparePayload($data);
+        if (! empty($data)) {
+            if ($payload === false) {
+                $url .= '?'.http_build_query($data);
+            } else {
+                $this->preparePayload($data);
+            }
         }
+
         $this->setOpt(CURLOPT_URL, $url);
         $this->setOpt(CURLOPT_CUSTOMREQUEST, 'DELETE');
         $this->exec();


### PR DESCRIPTION
Adding a ? to a url when there are no query parameters might be unnecessary.  This can cause a usability problem if an application uses a url without a ? to generate an authentication token.

Unless there is an RFC which expects a query symbol to be added to all requests for DELETE, PUT, and PATCH (regardless of query parameters), It might be clearer and cleaner to leave it off.