### PR TITLE
set getOpt function arg is optional

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -526,9 +526,14 @@ class Curl
      * @param mixed The value to check for the given $option
      * @return mixed
      */
-    public function getOpt($option)
+    public function getOpt($option = null)
     {
-        return curl_getinfo($this->curl, $option);
+        if (is_null($option)) {
+            $result = curl_getinfo($this->curl);
+        } else {
+            $result = curl_getinfo($this->curl, $option);
+        }
+        return $result;
     }
     
     /**


### PR DESCRIPTION
curl_getinfo function's second argument is optional ,  when I want get all curl info, I can't do it, so I think getOpt function is also.