### PR TITLE
Make exec public allows more customisation

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -199,14 +199,12 @@ class Curl
         return strlen($header_line);
     }
 
-    // protected methods
-
     /**
      * Execute the curl request based on the respective settings.
      *
      * @return int Returns the error code for the current curl request
      */
-    protected function exec()
+    public function exec()
     {
         $this->response_headers = array();
         $this->response = curl_exec($this->curl);
@@ -223,6 +221,8 @@ class Curl
 
         return $this->error_code;
     }
+    
+    // protected methods
 
     /**
      * @param array|object|string $data


### PR DESCRIPTION
This allows us to use the library even when for example the post request should be used with json payloal.