### PR TITLE
Add prepareJsonPayload on put method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-  "name": "curl/curl",
-  "description": "cURL class for PHP",
+  "name": "migrad/curl",
+  "description": "Fork from curl/curl: cURL class for PHP",
   "keywords": ["dot", "curl"],
-  "homepage": "https://github.com/php-mod/curl",
+  "homepage": "https://github.com/migrad/curl",
   "type": "library",
   "license": "MIT",
   "authors": [
@@ -18,6 +18,10 @@
     {
       "name": "user52",
       "homepage": "https://github.com/user52"
+    },
+    {
+      "name": "migrad"
+      "homepage": "https://github.com/migrad"
     }
   ],
   "require": {

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -374,15 +374,21 @@ class Curl
      * @param string $url The url to make the patch request
      * @param array $data Optional data to pass to the $url
      * @param bool $payload Whether the data should be transmitted trough payload or as get parameters of the string
+     * @param boolean $asJson Whether the data should be passed as json or not.
      * @return self
      */
-    public function patch($url, $data = array(), $payload = false)
+    public function patch($url, $data = array(), $payload = false, $asJson = false)
     {
         if (! empty($data)) {
             if ($payload === false) {
                 $url .= '?'.http_build_query($data);
             } else {
-                $this->preparePayload($data);
+                if ($asJson) {
+                    $this->prepareJsonPayload($data);
+                }
+                else {
+                    $this->preparePayload($data);
+                }
             }
         }
 

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -342,15 +342,21 @@ class Curl
      * @param string $url The url to make the put request
      * @param array $data Optional data to pass to the $url
      * @param bool $payload Whether the data should be transmitted trough payload or as get parameters of the string
+     * @param boolean $asJson Whether the data should be passed as json or not.
      * @return self
      */
-    public function put($url, $data = array(), $payload = false)
+    public function put($url, $data = array(), $payload = false, $asJson = false)
     {
         if (! empty($data)) {
             if ($payload === false) {
                 $url .= '?'.http_build_query($data);
             } else {
-                $this->preparePayload($data);
+                if ($asJson) {
+                    $this->prepareJsonPayload($data);
+                }
+                else {
+                    $this->preparePayload($data);
+                }
             }
         }
 


### PR DESCRIPTION
It is common for the payload to have a JSON format, this pull request adds that possibility.

It is also common for the format used in REST services to be XML (in addition to JSON), perhaps it would be better to have some public method to make these adaptations of an array to JSON / XML. Even in the case of XML it is common to work with objects and not with arrays.

