### PR TITLE
Update Curl.php

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -217,7 +217,7 @@ class Curl
         $this->http_error = $this->isError();
         $this->error = $this->curl_error || $this->http_error;
         $this->error_code = $this->error ? ($this->curl_error ? $this->getErrorCode() : $this->getHttpStatus()) : 0;
-        $this->request_headers = preg_split('/\r\n/', curl_getinfo($this->curl, CURLINFO_HEADER_OUT), null, PREG_SPLIT_NO_EMPTY);
+        $this->request_headers = preg_split('/\r\n/', curl_getinfo($this->curl, CURLINFO_HEADER_OUT), -1, PREG_SPLIT_NO_EMPTY);
         $this->http_error_message = $this->error ? (isset($this->response_headers['0']) ? $this->response_headers['0'] : '') : '';
         $this->error_message = $this->curl_error ? $this->getErrorMessage() : $this->http_error_message;
 


### PR DESCRIPTION
Passing null to this parameter emits a deprecation notice in PHP 8.1, and the sensible upgrade to this call would be setting $limit parameter to -1.