### PR TITLE
Purge

### DIFF
--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -315,6 +315,28 @@ class Curl
     }
 
     /**
+     * Purge Request
+     *
+     * A very common scenario to send a purge request is within the use of varnish, therefore 
+     * the optional hostname can be defined.
+     * 
+     * @param strng $url The url to make the purge request
+     * @param string $hostname An optional hostname which will be sent as http host header
+     * @return self
+     * @since
+     */
+    public function purge($url, $hostName = null)
+    {
+        $this->setOpt(CURLOPT_URL, $url);
+        $this->setOpt(CURLOPT_CUSTOMREQUEST, 'PURGE'); 
+        if ($hostName) {
+            $this->setOpt(CURLOPT_HTTPHEADER, ['Host: '. $hostName]);
+        }
+        $this->exec();
+        return $this;
+    }
+    
+    /**
      * Make a post request with optional post data.
      *
      * @param string $url  The url to make the post request

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -323,14 +323,14 @@ class Curl
      * @param strng $url The url to make the purge request
      * @param string $hostname An optional hostname which will be sent as http host header
      * @return self
-     * @since
+     * @since 2.4.0
      */
     public function purge($url, $hostName = null)
     {
         $this->setOpt(CURLOPT_URL, $url);
         $this->setOpt(CURLOPT_CUSTOMREQUEST, 'PURGE'); 
         if ($hostName) {
-            $this->setOpt(CURLOPT_HTTPHEADER, ['Host: '. $hostName]);
+            $this->setOpt(CURLOPT_HTTPHEADER, array('Host: '. $hostName));
         }
         $this->exec();
         return $this;


### PR DESCRIPTION
Purge requests as a common scenario, especially when working with the most used caching proxy varnish. This method will provide a purge request with the optional hostname defintion (which is important for varnish, but maybe we can also remove that and write into the phpdocs how to achieve that).

What do you think @amouhzi?

background: we have several situations for multiple projects to send purge request, then we always need to adjust the class, so  it would be nice to have that.