### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,5 @@ vendor              export-ignore
 actions.phpunit.xml export-ignore
 phpstan.phar        export-ignore
 phpstan.neon        export-ignore
+.php-cs-fixer.dist.php export-ignore
+CHANGELOG.md        export-ignore


### PR DESCRIPTION
PHP Coding-style fixer config not required for package installation.

Similarly with the changelog.md, the history of changes can be viewed in git.